### PR TITLE
add missing brace

### DIFF
--- a/GameData/KerbalismSimplex/System/ScienceRework/Groups/LabExperiments.cfg
+++ b/GameData/KerbalismSimplex/System/ScienceRework/Groups/LabExperiments.cfg
@@ -75,7 +75,8 @@
 						%mass = #$../../@KERBALISM_GROUP_SETTINGS/LAB_EXPERIMENTS/PROOF/SetupMass$
 						%cost = #$../../@KERBALISM_GROUP_SETTINGS/LAB_EXPERIMENTS/PROOF/SetupCost$
 					}
-
+			}
+			
 		@MODULE[Experiment]:HAS[#experiment_id[simplex_STUDY]]
 			{	%ec_rate = #$@KERBALISM_GROUP_SETTINGS/LAB_EXPERIMENTS/STUDY/ECCost$
 				%crew_operate = #$@KERBALISM_GROUP_SETTINGS/LAB_EXPERIMENTS/STUDY/CrewRequirement$


### PR DESCRIPTION
Missing brace in config for science lab was preventing the proper values from being applied for duration, etc.